### PR TITLE
feat: [sc-185133] Add healthcheck subcommand to swot

### DIFF
--- a/lib/Dockerfile
+++ b/lib/Dockerfile
@@ -9,4 +9,7 @@ COPY ./swot.rb /app/
 WORKDIR /app/
 CMD ["/app/swot-go"]
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=15 \
+  CMD ["/app/swot-go", "healthcheck"]
+
 EXPOSE 9900

--- a/lib/swot.go
+++ b/lib/swot.go
@@ -26,7 +26,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("HEALTHCHECK failed: %v", err)
 		}
-		defer resp.Body.Close()
+		resp.Body.Close()
 		if resp.StatusCode != http.StatusNoContent {
 			log.Fatalf("HEALTHCHECK unhealthy: %d", resp.StatusCode)
 		}

--- a/lib/swot.go
+++ b/lib/swot.go
@@ -20,6 +20,19 @@ var whitelist, blacklist map[string]struct{}
 
 func main() {
 
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		client := &http.Client{Timeout: 4 * time.Second}
+		resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/mit.edu", port))
+		if err != nil {
+			log.Fatalf("HEALTHCHECK failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			log.Fatalf("HEALTHCHECK unhealthy: %d", resp.StatusCode)
+		}
+		os.Exit(0)
+	}
+
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 	log.Println("swot INFO [STARTUP] Starting SWOT Service...")
 	log.Println("swot INFO [STARTUP] Listening and serving HTTP on " + fmt.Sprintf(":%v", port))


### PR DESCRIPTION
Probes GET /mit.edu (known academic domain, returns 204) to verify the service is up and handling requests. Same binary-subcommand pattern as core/maint/system no new tools needed in the scratch image.

https://app.shortcut.com/codeocean/story/185133